### PR TITLE
feat: add script to download, unzip and install Solace JS API

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+URL="https://products.solace.com/download/JS_API"
+ZIP_FILE="solace_js_api.zip"
+
+echo "📥 Downloading API..."
+curl -L -o "$ZIP_FILE" "$URL"
+
+echo "📦 Unpacking ZIP..."
+unzip -o "$ZIP_FILE" -d tmp_solace
+
+echo "📂 Moving solclient.js..."
+mkdir -p dist/js
+find tmp_solace -type f -path "*/lib/solclient.js" -exec mv {} dist/js/ \;
+
+echo "🧹 Cleaning up..."
+rm -rf tmp_solace "$ZIP_FILE"
+
+echo "✅ Done! File is located at dist/js/solclient.js"


### PR DESCRIPTION
Adds a shell script that:
- downloads the JS_API zip from products.solace.com
- extracts the archive
- moves lib/solclient.js into dist/js
- cleans up temporary files

The script is marked as executable.